### PR TITLE
Add streaming training updates across backend and frontend

### DIFF
--- a/e2e/ui.smoke.spec.ts
+++ b/e2e/ui.smoke.spec.ts
@@ -52,10 +52,18 @@ test.describe('offline UI smoke', () => {
     await captureScreenshot(page, path.join(SCREENSHOT_ROOT, '04_scatter.png'));
 
     await page.getByTestId('train-target').selectOption('species');
-    const eventStreamPromise = waitForEventStream(page, '/model/train', { optional: true, timeout: 10000 });
+    const eventStreamPromise = waitForEventStream(page, '/model/train/stream', {
+      optional: true,
+      timeout: 10000
+    });
     await page.getByTestId('train-button').click();
     await captureScreenshot(page, path.join(SCREENSHOT_ROOT, '05_training-start.png'));
     await eventStreamPromise;
+    const statusIndicator = page.getByTestId('training-status');
+    await expect(statusIndicator).toBeVisible({ timeout: 30000 });
+    const livePlotContainer = page.getByTestId('training-history-plot');
+    await waitForPlotlyCanvas(livePlotContainer.locator('.js-plotly-plot').first(), { timeout: 120000 });
+    await expect(page.getByTestId('latest-epoch')).toContainText(/Latest update/i, { timeout: 120000 });
     await expect(page.locator('.notification')).toContainText(/Model trained successfully/i, { timeout: 120000 });
     await expect(page.getByTestId('metrics-summary')).toBeVisible({ timeout: 120000 });
     await captureScreenshot(page, path.join(SCREENSHOT_ROOT, '06_training-complete.png'));

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -73,6 +73,7 @@ export default function App() {
   const [loading, setLoading] = useState(false);
   const [systemConfig, setSystemConfig] = useState(null);
   const [allowUploads, setAllowUploads] = useState(true);
+  const [liveHistory, setLiveHistory] = useState([]);
   const prefetchedDatasetId = useRef(null);
 
   const { message, variant, notify } = useNotification();
@@ -211,6 +212,7 @@ export default function App() {
     setModelId('');
     setMetrics(null);
     setEvaluation(null);
+    setLiveHistory([]);
   }, [currentDatasetId]);
 
   const handleDatasetSelect = async (datasetId) => {
@@ -257,6 +259,7 @@ export default function App() {
     setSplitId(result.split_id);
     setMetrics(result.metrics);
     setEvaluation(null);
+    setLiveHistory(result.history || []);
   };
 
   const handleEvaluate = async () => {
@@ -322,6 +325,7 @@ export default function App() {
         algorithms={algorithms}
         onTrainingComplete={handleTrainingComplete}
         onNotify={notify}
+        onProgress={setLiveHistory}
         disabled={!currentDatasetId || loading}
       />
       <EvaluationPanel
@@ -329,6 +333,7 @@ export default function App() {
         metrics={metrics}
         evaluation={evaluation}
         onEvaluate={handleEvaluate}
+        streamedHistory={liveHistory}
         disabled={loading}
       />
       <SystemConfigPanel config={systemConfig} />

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -18,6 +18,7 @@ vi.mock('../api/client.js', () => {
     getSystemConfig: vi.fn().mockResolvedValue({}),
     getHealth: vi.fn(),
     trainModel: vi.fn(),
+    openTrainingStream: vi.fn(),
     detectOutliers: vi.fn(),
     removeOutliers: vi.fn(),
     imputeDataset: vi.fn(),

--- a/frontend/src/__tests__/EvaluationPanel.test.jsx
+++ b/frontend/src/__tests__/EvaluationPanel.test.jsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-plotly.js', () => ({
+  __esModule: true,
+  default: (props) => <div data-testid={props['data-testid'] || 'plotly'} {...props} />
+}));
+
+import EvaluationPanel from '../components/EvaluationPanel.jsx';
+
+describe('EvaluationPanel training history fallback', () => {
+  it('renders streamed history when evaluation history is missing', () => {
+    const streamedHistory = [
+      { epoch: 1, train_loss: 0.6, val_loss: 0.5, metrics: { accuracy: 0.75 } },
+      { epoch: 2, train_loss: 0.5, val_loss: 0.45, metrics: { accuracy: 0.78 } }
+    ];
+
+    render(
+      <EvaluationPanel
+        modelId="model-1"
+        metrics={{ validation: { accuracy: 0.78 }, test: { accuracy: 0.76 } }}
+        evaluation={{}}
+        onEvaluate={vi.fn()}
+        streamedHistory={streamedHistory}
+        disabled={false}
+      />
+    );
+
+    expect(screen.getByTestId('evaluation-history-plot')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/ModelTrainer.test.jsx
+++ b/frontend/src/__tests__/ModelTrainer.test.jsx
@@ -1,0 +1,122 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-plotly.js', () => ({
+  __esModule: true,
+  default: (props) => <div data-testid={props['data-testid'] || 'plotly'} {...props} />
+}));
+
+const trainModelMock = vi.fn();
+const openTrainingStreamMock = vi.fn();
+
+vi.mock('../api/client.js', () => ({
+  trainModel: trainModelMock,
+  openTrainingStream: openTrainingStreamMock
+}));
+
+import ModelTrainer from '../components/ModelTrainer.jsx';
+
+const createMockStream = () => {
+  const listeners = new Map();
+  let errorHandler = null;
+  return {
+    addEventListener(type, handler) {
+      listeners.set(type, handler);
+    },
+    removeEventListener(type, handler) {
+      const current = listeners.get(type);
+      if (current === handler) {
+        listeners.delete(type);
+      }
+    },
+    close: vi.fn(),
+    emit(type, payload) {
+      const handler = listeners.get(type);
+      if (handler) {
+        handler({ data: JSON.stringify(payload) });
+      }
+    },
+    set onerror(handler) {
+      errorHandler = handler;
+    },
+    get onerror() {
+      return errorHandler;
+    },
+    triggerError(message) {
+      if (errorHandler) {
+        errorHandler({ data: JSON.stringify({ message }) });
+      }
+    }
+  };
+};
+
+describe('ModelTrainer live updates', () => {
+  beforeEach(() => {
+    trainModelMock.mockReset();
+    openTrainingStreamMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders streaming updates and resolves with final payload', async () => {
+    const stream = createMockStream();
+    openTrainingStreamMock.mockReturnValue(stream);
+
+    const onTrainingComplete = vi.fn();
+    const onProgress = vi.fn();
+    const onNotify = vi.fn();
+
+    render(
+      <ModelTrainer
+        datasetId="dataset-1"
+        splitId="split-1"
+        columns={['a', 'target']}
+        algorithms={[{ key: 'logistic_regression', label: 'Logistic Regression' }]}
+        onTrainingComplete={onTrainingComplete}
+        onNotify={onNotify}
+        onProgress={onProgress}
+        disabled={false}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('train-button'));
+    });
+
+    act(() => {
+      stream.emit('history', {
+        type: 'history',
+        entry: { epoch: 1, train_loss: 0.5, val_loss: 0.4, metrics: { accuracy: 0.8 } }
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('latest-epoch')).toHaveTextContent(/Epoch 1/i);
+    });
+    expect(onProgress).toHaveBeenCalled();
+
+    act(() => {
+      stream.emit('result', {
+        type: 'result',
+        payload: {
+          model_id: 'model-123',
+          metrics: { validation: { accuracy: 0.81 }, test: { accuracy: 0.79 } },
+          history: [{ epoch: 1, train_loss: 0.5 }],
+          split_id: 'split-1'
+        }
+      });
+    });
+
+    await waitFor(() => {
+      expect(onTrainingComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ model_id: 'model-123' })
+      );
+    });
+
+    expect(onNotify).toHaveBeenCalledWith(expect.stringMatching(/model trained successfully/i));
+    expect(screen.getByTestId('training-status')).toHaveTextContent(/Training complete/i);
+  });
+});

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -196,11 +196,27 @@ export async function getHealth() {
   return request('/health');
 }
 
+const serialisePayload = (payload) => {
+  const entries = Object.entries(payload).filter(([, value]) => value !== undefined);
+  return JSON.stringify(Object.fromEntries(entries));
+};
+
 export async function trainModel(payload) {
   return request('/model/train', {
     method: 'POST',
     body: JSON.stringify(payload)
   });
+}
+
+const buildStreamQuery = (payload) => {
+  const serialised = serialisePayload(payload);
+  return encodeURIComponent(serialised);
+};
+
+export function openTrainingStream(payload) {
+  const query = buildStreamQuery(payload);
+  const url = buildUrl(`/model/train/stream?payload=${query}`);
+  return new EventSource(url, { withCredentials: true });
 }
 
 export async function evaluateModel(modelId) {

--- a/frontend/src/components/EvaluationPanel.jsx
+++ b/frontend/src/components/EvaluationPanel.jsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Plot from 'react-plotly.js';
+
+import { buildTrainingHistoryFigure } from '../utils/trainingHistory.js';
 
 function MetricTable({ title, metrics }) {
   if (!metrics) {
@@ -23,7 +25,15 @@ function MetricTable({ title, metrics }) {
   );
 }
 
-export default function EvaluationPanel({ modelId, metrics, evaluation, onEvaluate, disabled }) {
+export default function EvaluationPanel({
+  modelId,
+  metrics,
+  evaluation,
+  onEvaluate,
+  streamedHistory = [],
+  disabled
+}) {
+  const fallbackHistory = useMemo(() => buildTrainingHistoryFigure(streamedHistory), [streamedHistory]);
   return (
     <div className="card">
       <div className="card-header">
@@ -52,6 +62,14 @@ export default function EvaluationPanel({ modelId, metrics, evaluation, onEvalua
               layout={{ ...evaluation.training_history.layout, autosize: true }}
               style={{ width: '100%', height: '100%' }}
             />
+          ) : fallbackHistory ? (
+            <div data-testid="evaluation-history-plot">
+              <Plot
+                data={fallbackHistory.data}
+                layout={{ ...fallbackHistory.layout, autosize: true }}
+                style={{ width: '100%', height: '100%' }}
+              />
+            </div>
           ) : (
             <p className="muted">Evaluate the model to visualise training progress.</p>
           )}

--- a/frontend/src/utils/trainingHistory.js
+++ b/frontend/src/utils/trainingHistory.js
@@ -1,0 +1,123 @@
+const isNumber = (value) => typeof value === 'number' && Number.isFinite(value);
+
+const normaliseNumeric = (value) => (isNumber(value) ? value : null);
+
+export function buildTrainingHistoryFigure(history = []) {
+  if (!Array.isArray(history) || history.length === 0) {
+    return null;
+  }
+
+  const epochs = history.map((entry, index) => {
+    if (entry == null || typeof entry !== 'object') {
+      return index + 1;
+    }
+    if (isNumber(entry.epoch)) {
+      return entry.epoch;
+    }
+    if (isNumber(entry.iteration)) {
+      return entry.iteration + 1;
+    }
+    return index + 1;
+  });
+
+  const data = [];
+
+  if (history.some((entry) => isNumber(entry?.train_loss))) {
+    data.push({
+      x: epochs,
+      y: history.map((entry) => normaliseNumeric(entry?.train_loss)),
+      mode: 'lines+markers',
+      name: 'Train Loss'
+    });
+  }
+
+  if (history.some((entry) => isNumber(entry?.val_loss))) {
+    data.push({
+      x: epochs,
+      y: history.map((entry) => normaliseNumeric(entry?.val_loss)),
+      mode: 'lines+markers',
+      name: 'Validation Loss'
+    });
+  }
+
+  if (history.some((entry) => isNumber(entry?.train_metric))) {
+    const metricName = history.find((entry) => entry?.metric)?.metric || 'Metric';
+    data.push({
+      x: epochs,
+      y: history.map((entry) => normaliseNumeric(entry?.train_metric)),
+      mode: 'lines+markers',
+      name: `Train ${metricName}`
+    });
+  }
+
+  if (history.some((entry) => isNumber(entry?.validation_metric))) {
+    const metricName = history.find((entry) => entry?.metric)?.metric || 'Metric';
+    data.push({
+      x: epochs,
+      y: history.map((entry) => normaliseNumeric(entry?.validation_metric)),
+      mode: 'lines+markers',
+      name: `Validation ${metricName}`,
+      yaxis: 'y2'
+    });
+  }
+
+  const metricsEntries = history.filter((entry) => entry?.metrics && typeof entry.metrics === 'object');
+  if (metricsEntries.length > 0) {
+    const latestMetrics = metricsEntries[metricsEntries.length - 1].metrics;
+    const metricKeys = Object.keys(latestMetrics);
+    if (metricKeys.length > 0) {
+      const preferredKeys = ['accuracy', 'f1', 'r2', 'mae'];
+      const selectedKey = preferredKeys.find((key) => key in latestMetrics) || metricKeys[0];
+      data.push({
+        x: epochs,
+        y: history.map((entry) => normaliseNumeric(entry?.metrics?.[selectedKey])),
+        mode: 'lines+markers',
+        name: `Validation ${selectedKey}`,
+        yaxis: 'y2'
+      });
+    }
+  }
+
+  const layout = {
+    title: 'Training History',
+    xaxis: { title: 'Epoch' },
+    yaxis: { title: 'Loss' },
+    template: 'plotly_white'
+  };
+
+  if (data.some((trace) => trace.yaxis === 'y2')) {
+    layout.yaxis2 = {
+      title: 'Validation Metric',
+      overlaying: 'y',
+      side: 'right'
+    };
+  }
+
+  if (data.length === 0) {
+    data.push({
+      x: epochs,
+      y: history.map(() => 0),
+      mode: 'lines+markers',
+      name: 'Progress'
+    });
+  }
+
+  return { data, layout };
+}
+
+export function latestHistoryLabel(history = []) {
+  if (!Array.isArray(history) || history.length === 0) {
+    return null;
+  }
+  const latest = history[history.length - 1];
+  if (isNumber(latest?.epoch)) {
+    return `Epoch ${latest.epoch}`;
+  }
+  if (isNumber(latest?.iteration)) {
+    return `Iteration ${latest.iteration + 1}`;
+  }
+  if (latest?.stage) {
+    return latest.stage;
+  }
+  return `Update ${history.length}`;
+}

--- a/tests/backend/api/test_model_stream.py
+++ b/tests/backend/api/test_model_stream.py
@@ -1,0 +1,61 @@
+import json
+import json
+from typing import Generator, List, Tuple
+
+from fastapi.testclient import TestClient
+
+from backend.app.main import app
+from backend.app.services.data_manager import data_manager
+
+client = TestClient(app)
+
+
+def _iter_sse(response) -> Generator[Tuple[str, str], None, None]:
+  buffer = ''
+  for chunk in response.iter_text():
+    buffer += chunk
+    while '\n\n' in buffer:
+      block, buffer = buffer.split('\n\n', 1)
+      event_type = 'message'
+      data_lines: List[str] = []
+      for line in block.splitlines():
+        if line.startswith(':'):
+          continue
+        if line.startswith('event:'):
+          event_type = line[len('event:') :].strip()
+        elif line.startswith('data:'):
+          data_lines.append(line[len('data:') :].strip())
+      yield event_type, '\n'.join(data_lines)
+
+
+def test_train_stream_emits_history_and_result():
+  metadata = data_manager.load_sample_dataset('titanic')
+  payload = {
+    'dataset_id': metadata.dataset_id,
+    'target_column': 'Survived',
+    'task_type': 'classification',
+    'algorithm': 'logistic_regression',
+    'hyperparameters': {'max_iter': 50},
+  }
+
+  params = {'payload': json.dumps(payload)}
+
+  with client.stream('GET', '/model/train/stream', params=params) as response:
+    assert response.status_code == 200
+    events = []
+    for event_type, data in _iter_sse(response):
+      events.append((event_type, data))
+      if event_type == 'result':
+        break
+
+  event_types = [event for event, _ in events]
+  assert 'history' in event_types
+  assert 'result' in event_types
+
+  result_data = next(data for event, data in events if event == 'result')
+  result_payload = json.loads(result_data).get('payload', {})
+
+  assert result_payload.get('model_id')
+  assert result_payload.get('split_id')
+  assert result_payload.get('metrics', {}).get('validation')
+  assert isinstance(result_payload.get('history'), list)


### PR DESCRIPTION
## Summary
- add progress callback support to the training service and expose an SSE endpoint for incremental model updates
- stream live training history into the React trainer and evaluation panels with shared plotting utilities
- cover the new functionality with backend integration, frontend component, and Playwright end-to-end assertions

## Testing
- `pytest tests/backend/api/test_model_stream.py` *(fails: pandas dependency unavailable in environment)*
- `npm run test:unit -- ModelTrainer.test.jsx EvaluationPanel.test.jsx` *(fails: vitest binary missing; install dependencies to run)*

------
https://chatgpt.com/codex/tasks/task_e_68e36f6c028c832480888488f8a254ed