### PR TITLE
feat: add interactive visualization customization controls

### DIFF
--- a/frontend/src/__tests__/VisualizationPanel.test.jsx
+++ b/frontend/src/__tests__/VisualizationPanel.test.jsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import VisualizationPanel from '../components/VisualizationPanel.jsx';
+
+const plotRenderMock = vi.hoisted(() => vi.fn());
+const getHistogramMock = vi.hoisted(() => vi.fn());
+const getScatterMock = vi.hoisted(() => vi.fn());
+
+vi.mock('react-plotly.js', () => ({
+  __esModule: true,
+  default: (props) => {
+    plotRenderMock(props);
+    return <div data-testid={props['data-testid'] || 'plotly'} />;
+  }
+}));
+
+vi.mock('../api/client.js', () => ({
+  __esModule: true,
+  getHistogram: getHistogramMock,
+  getScatter: getScatterMock
+}));
+
+describe('VisualizationPanel customization', () => {
+  beforeEach(() => {
+    plotRenderMock.mockReset();
+    getHistogramMock.mockReset();
+    getScatterMock.mockReset();
+  });
+
+  it('exposes histogram customization controls that update the plot', async () => {
+    getHistogramMock.mockResolvedValue({
+      figure: {
+        data: [
+          {
+            type: 'histogram',
+            marker: {},
+            nbinsx: 10
+          }
+        ],
+        layout: {
+          title: { text: 'Base histogram' },
+          xaxis: { showgrid: false },
+          yaxis: { showgrid: false }
+        }
+      }
+    });
+
+    render(
+      <VisualizationPanel
+        datasetId="demo"
+        columns={['age', 'fare']}
+        onNotify={vi.fn()}
+        disabled={false}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/column/i), { target: { value: 'age' } });
+    fireEvent.click(screen.getByRole('button', { name: /generate histogram/i }));
+
+    await waitFor(() => expect(getHistogramMock).toHaveBeenCalled());
+    await screen.findByTestId('histogram-plot');
+
+    fireEvent.click(screen.getByRole('button', { name: /customize histogram options/i }));
+    const binInput = await screen.findByLabelText(/bin count/i);
+    fireEvent.change(binInput, { target: { value: '15' } });
+    fireEvent.change(screen.getByLabelText(/opacity/i), { target: { value: '0.5' } });
+
+    await waitFor(() => {
+      const lastCall = plotRenderMock.mock.calls.at(-1)?.[0];
+      expect(lastCall?.data?.[0]?.nbinsx).toBe(15);
+      expect(lastCall?.data?.[0]?.marker?.opacity).toBeCloseTo(0.5);
+      expect(lastCall?.layout?.xaxis?.showgrid).toBe(true);
+    });
+  });
+
+  it('applies scatter customization updates to layout and markers', async () => {
+    getScatterMock.mockResolvedValue({
+      figure: {
+        data: [
+          {
+            type: 'scatter',
+            mode: 'markers',
+            marker: { size: 6, opacity: 0.6, line: { width: 0 } }
+          }
+        ],
+        layout: {
+          title: { text: 'Base scatter' },
+          xaxis: { title: { text: 'X' } },
+          yaxis: { title: { text: 'Y' } },
+          showlegend: true
+        }
+      }
+    });
+
+    render(
+      <VisualizationPanel
+        datasetId="demo"
+        columns={['age', 'fare', 'pclass']}
+        onNotify={vi.fn()}
+        disabled={false}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/x axis/i), { target: { value: 'age' } });
+    fireEvent.change(screen.getByLabelText(/y axis/i), { target: { value: 'fare' } });
+    const scatterButtons = screen.getAllByRole('button', { name: /generate scatter/i });
+    fireEvent.click(scatterButtons[0]);
+
+    await waitFor(() => expect(getScatterMock).toHaveBeenCalled());
+    await screen.findByTestId('scatter-plot');
+
+    const scatterGearButtons = screen.getAllByRole('button', { name: /customize scatter plot options/i });
+    fireEvent.click(scatterGearButtons[0]);
+    fireEvent.change(await screen.findByLabelText(/marker size/i), { target: { value: '12' } });
+    fireEvent.change(screen.getByLabelText(/background color/i), { target: { value: '#222222' } });
+    fireEvent.change(screen.getByLabelText(/x axis title/i), { target: { value: 'Age (years)' } });
+
+    await waitFor(() => {
+      const lastCall = plotRenderMock.mock.calls.at(-1)?.[0];
+      expect(lastCall?.data?.[0]?.marker?.size).toBe(12);
+      expect(lastCall?.layout?.plot_bgcolor).toBe('#222222');
+      expect(lastCall?.layout?.xaxis?.title?.text).toBe('Age (years)');
+    });
+  });
+});

--- a/frontend/src/components/VisualizationPanel.jsx
+++ b/frontend/src/components/VisualizationPanel.jsx
@@ -1,24 +1,72 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import Plot from 'react-plotly.js';
 import { getHistogram, getScatter } from '../api/client.js';
+import ConfigurablePlotSection from './visualization/ConfigurablePlotSection.jsx';
+import HistogramOptionsForm from './visualization/HistogramOptionsForm.jsx';
+import ScatterOptionsForm from './visualization/ScatterOptionsForm.jsx';
+import {
+  applyHistogramOptions,
+  applyScatterOptions,
+  createDefaultHistogramOptions,
+  createDefaultScatterOptions
+} from '../utils/plotCustomization.js';
 
 export default function VisualizationPanel({ datasetId, columns, onNotify, disabled }) {
   const [histColumn, setHistColumn] = useState('');
-  const [histFigure, setHistFigure] = useState(null);
   const [scatterX, setScatterX] = useState('');
   const [scatterY, setScatterY] = useState('');
   const [scatterColor, setScatterColor] = useState('');
-  const [scatterFigure, setScatterFigure] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [histFigure, setHistFigure] = useState(null);
+  const [scatterFigure, setScatterFigure] = useState(null);
+  const [histBaseFigure, setHistBaseFigure] = useState(null);
+  const [scatterBaseFigure, setScatterBaseFigure] = useState(null);
+  const [histOptions, setHistOptions] = useState(() => createDefaultHistogramOptions());
+  const [scatterOptions, setScatterOptions] = useState(() => createDefaultScatterOptions());
+  const [histOptionsOpen, setHistOptionsOpen] = useState(false);
+  const [scatterOptionsOpen, setScatterOptionsOpen] = useState(false);
+
+  const columnSignature = useMemo(() => columns.join(','), [columns]);
 
   useEffect(() => {
     setHistColumn('');
-    setHistFigure(null);
     setScatterX('');
     setScatterY('');
     setScatterColor('');
+    setLoading(false);
+    setHistBaseFigure(null);
+    setScatterBaseFigure(null);
+    setHistFigure(null);
     setScatterFigure(null);
-  }, [datasetId, columns.join(',')]);
+    setHistOptions(createDefaultHistogramOptions());
+    setScatterOptions(createDefaultScatterOptions());
+    setHistOptionsOpen(false);
+    setScatterOptionsOpen(false);
+  }, [datasetId, columnSignature]);
+
+  useEffect(() => {
+    if (!histBaseFigure) {
+      setHistFigure(null);
+      return;
+    }
+    setHistFigure(applyHistogramOptions(histBaseFigure, histOptions));
+  }, [histBaseFigure, histOptions]);
+
+  useEffect(() => {
+    if (!scatterBaseFigure) {
+      setScatterFigure(null);
+      return;
+    }
+    setScatterFigure(applyScatterOptions(scatterBaseFigure, scatterOptions));
+  }, [scatterBaseFigure, scatterOptions]);
+
+  const updateHistogramOption = (key, value) => {
+    setHistOptions((previous) => ({ ...previous, [key]: value }));
+  };
+
+  const updateScatterOption = (key, value) => {
+    setScatterOptions((previous) => ({ ...previous, [key]: value }));
+  };
 
   const handleHistogram = async () => {
     if (!datasetId || !histColumn) {
@@ -28,7 +76,7 @@ export default function VisualizationPanel({ datasetId, columns, onNotify, disab
     setLoading(true);
     try {
       const response = await getHistogram(datasetId, histColumn);
-      setHistFigure(response.figure);
+      setHistBaseFigure(response.figure);
     } catch (error) {
       onNotify(error.message);
     } finally {
@@ -48,7 +96,7 @@ export default function VisualizationPanel({ datasetId, columns, onNotify, disab
         y: scatterY,
         color: scatterColor || undefined
       });
-      setScatterFigure(response.figure);
+      setScatterBaseFigure(response.figure);
     } catch (error) {
       onNotify(error.message);
     } finally {
@@ -62,10 +110,26 @@ export default function VisualizationPanel({ datasetId, columns, onNotify, disab
         <h2>3. Explore visually</h2>
       </div>
       <div className="card-body viz-grid">
-        <div>
-          <h3>Histogram</h3>
-          <label>Column</label>
-          <select value={histColumn} onChange={(event) => setHistColumn(event.target.value)} disabled={disabled}>
+        <ConfigurablePlotSection
+          title="Histogram"
+          disabled={disabled}
+          isConfigOpen={histOptionsOpen}
+          onToggleConfig={() => setHistOptionsOpen((open) => !open)}
+          configContent={
+            <HistogramOptionsForm
+              options={histOptions}
+              onChange={updateHistogramOption}
+              disabled={disabled}
+            />
+          }
+        >
+          <label htmlFor="histogram-column">Column</label>
+          <select
+            id="histogram-column"
+            value={histColumn}
+            onChange={(event) => setHistColumn(event.target.value)}
+            disabled={disabled}
+          >
             <option value="">-- choose column --</option>
             {columns.map((column) => (
               <option key={column} value={column}>
@@ -76,12 +140,35 @@ export default function VisualizationPanel({ datasetId, columns, onNotify, disab
           <button type="button" onClick={handleHistogram} disabled={disabled || loading}>
             Generate histogram
           </button>
-          {histFigure && <Plot data={histFigure.data} layout={histFigure.layout} style={{ width: '100%', height: '100%' }} />}
-        </div>
-        <div>
-          <h3>Scatter plot</h3>
-          <label>X axis</label>
-          <select value={scatterX} onChange={(event) => setScatterX(event.target.value)} disabled={disabled}>
+          {histFigure && (
+            <Plot
+              data={histFigure.data}
+              layout={histFigure.layout}
+              style={{ width: '100%', height: '100%' }}
+              data-testid="histogram-plot"
+            />
+          )}
+        </ConfigurablePlotSection>
+        <ConfigurablePlotSection
+          title="Scatter plot"
+          disabled={disabled}
+          isConfigOpen={scatterOptionsOpen}
+          onToggleConfig={() => setScatterOptionsOpen((open) => !open)}
+          configContent={
+            <ScatterOptionsForm
+              options={scatterOptions}
+              onChange={updateScatterOption}
+              disabled={disabled}
+            />
+          }
+        >
+          <label htmlFor="scatter-x">X axis</label>
+          <select
+            id="scatter-x"
+            value={scatterX}
+            onChange={(event) => setScatterX(event.target.value)}
+            disabled={disabled}
+          >
             <option value="">-- choose X --</option>
             {columns.map((column) => (
               <option key={column} value={column}>
@@ -89,8 +176,13 @@ export default function VisualizationPanel({ datasetId, columns, onNotify, disab
               </option>
             ))}
           </select>
-          <label>Y axis</label>
-          <select value={scatterY} onChange={(event) => setScatterY(event.target.value)} disabled={disabled}>
+          <label htmlFor="scatter-y">Y axis</label>
+          <select
+            id="scatter-y"
+            value={scatterY}
+            onChange={(event) => setScatterY(event.target.value)}
+            disabled={disabled}
+          >
             <option value="">-- choose Y --</option>
             {columns.map((column) => (
               <option key={column} value={column}>
@@ -98,8 +190,13 @@ export default function VisualizationPanel({ datasetId, columns, onNotify, disab
               </option>
             ))}
           </select>
-          <label>Color grouping (optional)</label>
-          <select value={scatterColor} onChange={(event) => setScatterColor(event.target.value)} disabled={disabled}>
+          <label htmlFor="scatter-color">Color grouping (optional)</label>
+          <select
+            id="scatter-color"
+            value={scatterColor}
+            onChange={(event) => setScatterColor(event.target.value)}
+            disabled={disabled}
+          >
             <option value="">-- none --</option>
             {columns.map((column) => (
               <option key={column} value={column}>
@@ -110,8 +207,15 @@ export default function VisualizationPanel({ datasetId, columns, onNotify, disab
           <button type="button" onClick={handleScatter} disabled={disabled || loading}>
             Generate scatter
           </button>
-          {scatterFigure && <Plot data={scatterFigure.data} layout={scatterFigure.layout} style={{ width: '100%', height: '100%' }} />}
-        </div>
+          {scatterFigure && (
+            <Plot
+              data={scatterFigure.data}
+              layout={scatterFigure.layout}
+              style={{ width: '100%', height: '100%' }}
+              data-testid="scatter-plot"
+            />
+          )}
+        </ConfigurablePlotSection>
       </div>
     </div>
   );

--- a/frontend/src/components/visualization/ConfigurablePlotSection.jsx
+++ b/frontend/src/components/visualization/ConfigurablePlotSection.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+export default function ConfigurablePlotSection({
+  title,
+  children,
+  configContent,
+  disabled,
+  isConfigOpen,
+  onToggleConfig
+}) {
+  return (
+    <div className="viz-section">
+      <div className="viz-section-heading">
+        <h3>{title}</h3>
+        <button
+          type="button"
+          className="viz-config-button"
+          onClick={onToggleConfig}
+          aria-label={`Customize ${title.toLowerCase()} options`}
+          aria-expanded={isConfigOpen}
+          disabled={disabled}
+        >
+          <span aria-hidden="true">⚙</span>
+        </button>
+      </div>
+      {isConfigOpen && <div className="viz-config-panel">{configContent}</div>}
+      <div className="viz-section-body">{children}</div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/visualization/HistogramOptionsForm.jsx
+++ b/frontend/src/components/visualization/HistogramOptionsForm.jsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import OptionControl from './OptionControl.jsx';
+
+export default function HistogramOptionsForm({ options, onChange, disabled }) {
+  const handleNumberChange = (key) => (event) => {
+    const value = Number(event.target.value);
+    onChange(key, Number.isNaN(value) ? options[key] : value);
+  };
+
+  const handleSelectChange = (key) => (event) => {
+    onChange(key, event.target.value);
+  };
+
+  const handleCheckboxChange = (key) => (event) => {
+    onChange(key, event.target.checked);
+  };
+
+  const handleTextChange = (key) => (event) => {
+    onChange(key, event.target.value);
+  };
+
+  return (
+    <div className="options-grid">
+      <OptionControl id="hist-bin-count" label="Bin count" description="Adjust resolution of the bars.">
+        <input
+          id="hist-bin-count"
+          type="number"
+          min={1}
+          max={200}
+          value={options.binCount}
+          onChange={handleNumberChange('binCount')}
+          disabled={disabled}
+        />
+      </OptionControl>
+      <OptionControl id="hist-orientation" label="Orientation">
+        <select
+          id="hist-orientation"
+          value={options.orientation}
+          onChange={handleSelectChange('orientation')}
+          disabled={disabled}
+        >
+          <option value="v">Vertical</option>
+          <option value="h">Horizontal</option>
+        </select>
+      </OptionControl>
+      <OptionControl id="hist-color" label="Bar color">
+        <input
+          id="hist-color"
+          type="color"
+          value={options.color}
+          onChange={handleTextChange('color')}
+          disabled={disabled}
+        />
+      </OptionControl>
+      <OptionControl id="hist-opacity" label="Opacity" description="0 is transparent, 1 is solid.">
+        <input
+          id="hist-opacity"
+          type="range"
+          min={0.1}
+          max={1}
+          step={0.05}
+          value={options.opacity}
+          onChange={handleNumberChange('opacity')}
+          disabled={disabled}
+        />
+        <span className="option-value-indicator">{options.opacity.toFixed(2)}</span>
+      </OptionControl>
+      <OptionControl id="hist-bar-gap" label="Bar gap" description="Spacing between bars.">
+        <input
+          id="hist-bar-gap"
+          type="range"
+          min={0}
+          max={0.5}
+          step={0.05}
+          value={options.barGap}
+          onChange={handleNumberChange('barGap')}
+          disabled={disabled}
+        />
+        <span className="option-value-indicator">{options.barGap.toFixed(2)}</span>
+      </OptionControl>
+      <OptionControl id="hist-show-grid" label="Grid lines">
+        <div className="option-inline-checkbox">
+          <input
+            id="hist-show-grid"
+            type="checkbox"
+            checked={options.showGrid}
+            onChange={handleCheckboxChange('showGrid')}
+            disabled={disabled}
+          />
+          <span>Show axis grid</span>
+        </div>
+      </OptionControl>
+      <OptionControl id="hist-legend" label="Legend orientation">
+        <select
+          id="hist-legend"
+          value={options.legendOrientation}
+          onChange={handleSelectChange('legendOrientation')}
+          disabled={disabled}
+        >
+          <option value="v">Vertical</option>
+          <option value="h">Horizontal</option>
+        </select>
+      </OptionControl>
+      <OptionControl id="hist-title" label="Custom title">
+        <input
+          id="hist-title"
+          type="text"
+          placeholder="Override plot title"
+          value={options.title}
+          onChange={handleTextChange('title')}
+          disabled={disabled}
+        />
+      </OptionControl>
+    </div>
+  );
+}
+

--- a/frontend/src/components/visualization/OptionControl.jsx
+++ b/frontend/src/components/visualization/OptionControl.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function OptionControl({ id, label, description = '', children }) {
+  return (
+    <div className="option-control">
+      <div className="option-control-labels">
+        <label htmlFor={id}>{label}</label>
+        {description && <span className="option-control-description">{description}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+

--- a/frontend/src/components/visualization/ScatterOptionsForm.jsx
+++ b/frontend/src/components/visualization/ScatterOptionsForm.jsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import OptionControl from './OptionControl.jsx';
+
+export default function ScatterOptionsForm({ options, onChange, disabled }) {
+  const handleNumberChange = (key) => (event) => {
+    const value = Number(event.target.value);
+    onChange(key, Number.isNaN(value) ? options[key] : value);
+  };
+
+  const handleCheckboxChange = (key) => (event) => {
+    onChange(key, event.target.checked);
+  };
+
+  const handleTextChange = (key) => (event) => {
+    onChange(key, event.target.value);
+  };
+
+  return (
+    <div className="options-grid">
+      <OptionControl id="scatter-marker-size" label="Marker size">
+        <input
+          id="scatter-marker-size"
+          type="number"
+          min={1}
+          max={40}
+          value={options.markerSize}
+          onChange={handleNumberChange('markerSize')}
+          disabled={disabled}
+        />
+      </OptionControl>
+      <OptionControl id="scatter-marker-opacity" label="Marker opacity">
+        <input
+          id="scatter-marker-opacity"
+          type="range"
+          min={0.1}
+          max={1}
+          step={0.05}
+          value={options.markerOpacity}
+          onChange={handleNumberChange('markerOpacity')}
+          disabled={disabled}
+        />
+        <span className="option-value-indicator">{options.markerOpacity.toFixed(2)}</span>
+      </OptionControl>
+      <OptionControl id="scatter-line-width" label="Outline width" description="Adds a border around markers.">
+        <input
+          id="scatter-line-width"
+          type="range"
+          min={0}
+          max={5}
+          step={0.5}
+          value={options.lineWidth}
+          onChange={handleNumberChange('lineWidth')}
+          disabled={disabled}
+        />
+        <span className="option-value-indicator">{options.lineWidth.toFixed(1)}</span>
+      </OptionControl>
+      <OptionControl id="scatter-show-legend" label="Legend">
+        <div className="option-inline-checkbox">
+          <input
+            id="scatter-show-legend"
+            type="checkbox"
+            checked={options.showLegend}
+            onChange={handleCheckboxChange('showLegend')}
+            disabled={disabled}
+          />
+          <span>Show legend</span>
+        </div>
+      </OptionControl>
+      <OptionControl id="scatter-title" label="Custom title">
+        <input
+          id="scatter-title"
+          type="text"
+          placeholder="Override plot title"
+          value={options.title}
+          onChange={handleTextChange('title')}
+          disabled={disabled}
+        />
+      </OptionControl>
+      <OptionControl id="scatter-x-title" label="X axis title">
+        <input
+          id="scatter-x-title"
+          type="text"
+          placeholder="Override X axis"
+          value={options.xTitle}
+          onChange={handleTextChange('xTitle')}
+          disabled={disabled}
+        />
+      </OptionControl>
+      <OptionControl id="scatter-y-title" label="Y axis title">
+        <input
+          id="scatter-y-title"
+          type="text"
+          placeholder="Override Y axis"
+          value={options.yTitle}
+          onChange={handleTextChange('yTitle')}
+          disabled={disabled}
+        />
+      </OptionControl>
+      <OptionControl id="scatter-background" label="Background color">
+        <input
+          id="scatter-background"
+          type="color"
+          value={options.background}
+          onChange={handleTextChange('background')}
+          disabled={disabled}
+        />
+      </OptionControl>
+    </div>
+  );
+}
+

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -238,6 +238,96 @@ button:not(:disabled):hover {
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 
+.viz-section {
+  display: grid;
+  gap: 1rem;
+  background-color: #f8fafc;
+  padding: 1.2rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 12px;
+}
+
+.viz-section-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.viz-section-heading h3 {
+  margin: 0;
+}
+
+.viz-config-button {
+  border: none;
+  background: transparent;
+  font-size: 1.2rem;
+  cursor: pointer;
+  color: #1e3a8a;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  width: 2.2rem;
+  height: 2.2rem;
+  transition: background-color 0.2s ease;
+}
+
+.viz-config-button:not(:disabled):hover,
+.viz-config-button[aria-expanded='true'] {
+  background-color: rgba(37, 99, 235, 0.1);
+}
+
+.viz-config-panel {
+  background-color: #fff;
+  border-radius: 10px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  padding: 1rem;
+  box-shadow: inset 0 1px 3px rgba(15, 23, 42, 0.05);
+}
+
+.viz-section-body {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.options-grid {
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.option-control {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.option-control-labels {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.9rem;
+  color: #0f172a;
+}
+
+.option-control-description {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.option-inline-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: #0f172a;
+}
+
+.option-value-indicator {
+  font-size: 0.8rem;
+  color: #1e3a8a;
+  font-weight: 600;
+}
+
 .model-grid {
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }

--- a/frontend/src/utils/plotCustomization.js
+++ b/frontend/src/utils/plotCustomization.js
@@ -1,0 +1,117 @@
+const cloneFigure = (figure) => JSON.parse(JSON.stringify(figure));
+
+export const createDefaultHistogramOptions = () => ({
+  binCount: 30,
+  orientation: 'v',
+  color: '#2563eb',
+  opacity: 0.75,
+  barGap: 0.05,
+  showGrid: true,
+  legendOrientation: 'v',
+  title: ''
+});
+
+export const createDefaultScatterOptions = () => ({
+  markerSize: 8,
+  markerOpacity: 0.8,
+  lineWidth: 0,
+  showLegend: true,
+  title: '',
+  xTitle: '',
+  yTitle: '',
+  background: '#ffffff'
+});
+
+export const applyHistogramOptions = (figure, options) => {
+  if (!figure) {
+    return null;
+  }
+
+  const next = cloneFigure(figure);
+  next.data = (next.data || []).map((trace) => {
+    const orientation = options.orientation;
+    const marker = { ...(trace.marker || {}), color: options.color, opacity: options.opacity };
+    return {
+      ...trace,
+      marker,
+      orientation,
+      nbinsx: orientation === 'v' ? options.binCount : undefined,
+      nbinsy: orientation === 'h' ? options.binCount : undefined
+    };
+  });
+
+  const baseTitle = next.layout?.title?.text || '';
+  next.layout = {
+    ...next.layout,
+    bargap: options.barGap,
+    legend: {
+      ...(next.layout?.legend || {}),
+      orientation: options.legendOrientation
+    },
+    title: {
+      ...(next.layout?.title || {}),
+      text: options.title || baseTitle
+    },
+    xaxis: {
+      ...(next.layout?.xaxis || {}),
+      showgrid: options.showGrid
+    },
+    yaxis: {
+      ...(next.layout?.yaxis || {}),
+      showgrid: options.showGrid
+    }
+  };
+
+  return next;
+};
+
+export const applyScatterOptions = (figure, options) => {
+  if (!figure) {
+    return null;
+  }
+
+  const next = cloneFigure(figure);
+  next.data = (next.data || []).map((trace) => ({
+    ...trace,
+    marker: {
+      ...(trace.marker || {}),
+      size: options.markerSize,
+      opacity: options.markerOpacity,
+      line: {
+        ...(trace.marker?.line || {}),
+        width: options.lineWidth
+      }
+    }
+  }));
+
+  const baseTitle = next.layout?.title?.text || '';
+  const baseX = next.layout?.xaxis?.title?.text || '';
+  const baseY = next.layout?.yaxis?.title?.text || '';
+
+  next.layout = {
+    ...next.layout,
+    showlegend: options.showLegend,
+    title: {
+      ...(next.layout?.title || {}),
+      text: options.title || baseTitle
+    },
+    xaxis: {
+      ...(next.layout?.xaxis || {}),
+      title: {
+        ...(next.layout?.xaxis?.title || {}),
+        text: options.xTitle || baseX
+      }
+    },
+    yaxis: {
+      ...(next.layout?.yaxis || {}),
+      title: {
+        ...(next.layout?.yaxis?.title || {}),
+        text: options.yTitle || baseY
+      }
+    },
+    plot_bgcolor: options.background,
+    paper_bgcolor: options.background
+  };
+
+  return next;
+};


### PR DESCRIPTION
## Summary
- add modular plot sections with gear toggles so users can open customization panels for histogram and scatter charts
- apply reusable histogram and scatter option utilities to update plotly figures in place
- cover the new UI behavior with unit tests for customization workflows

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e6379e3c008324887d6e36b4c897e2